### PR TITLE
Some small suggested changes to the GMSE app. 

### DIFF
--- a/R/gmse_gui/app.R
+++ b/R/gmse_gui/app.R
@@ -2,6 +2,7 @@ library(shiny)
 library(shinydashboard)
 library(shinyjs)
 library(GMSE)
+library(shinycssloaders)
 
 ################################################################################
 # Note: This code is for uploading to the shiny server, the gui called from the
@@ -51,8 +52,7 @@ sidebar <-   dashboardSidebar(
                 
                 div(align="center"),
                 
-                menuItem("Run simulation", tabName = "run", 
-                         icon = icon("play", class=menuIconClass)),
+                actionButton("go", "Run Simulation Now", icon = icon("play"), style="color: #ffffff; background-color: #006400; border-color: #084908"),
                 
                 uiOutput("sim_output"),
                 
@@ -635,27 +635,16 @@ body <- dashboardBody(
                            
                     )
             ),
-            
-            tabItem("run",
-                    
-                    headerPanel(title = "Run a simulation"),
-                    
-                    column(width = 6, offset = 0, style='padding:0px;',
-                           
-                           hr(),
-                           
-                           actionButton("go", "Run Simulation Now")
-                           
-                    )
-            ),
-            
+
             tabItem("plotting",
                     
                     headerPanel(title = "Simulation output (please be patient)"),
                     
                     hr(),
                     
-                    plotOutput("plot1", height = 900, width = 700)
+                    withSpinner(type = 5, color.background = "#ecf0f5",
+                        plotOutput("plot1", height = 900, width = 700)
+                    )
             ),
             
             tabItem("plot_effort",
@@ -664,7 +653,10 @@ body <- dashboardBody(
                     
                     hr(),
                     
-                    plotOutput("plot2", height = 900, width = 700)
+                    withSpinner(type = 5, color.background = "#ecf0f5",
+                        plotOutput("plot2", height = 900, width = 700)
+                    )
+                    
             ),
             
             tabItem("resource_tab",
@@ -673,7 +665,9 @@ body <- dashboardBody(
                     
                     hr(),
                     
-                    tableOutput("table1")
+                    withSpinner(type = 5, color.background = "#ecf0f5",
+                        tableOutput("table1")
+                    )
             ),
             
             tabItem("cost_tab",
@@ -682,7 +676,10 @@ body <- dashboardBody(
                     
                     hr(),
                     
-                    tableOutput("table2")
+                    withSpinner(type = 5, color.background = "#ecf0f5",
+                        tableOutput("table2")
+                    )
+
             ),
             
             tabItem("action_tab",
@@ -691,7 +688,10 @@ body <- dashboardBody(
                     
                     hr(),
                     
-                    tableOutput("table3")
+                    withSpinner(type = 5, color.background = "#ecf0f5",
+                        tableOutput("table3")
+                    )
+                                
             ),
             
             tabItem("help",
@@ -815,6 +815,10 @@ server <- function(input, output){
              times_feeding  = input$times_feeding,
              ownership_var  = input$ownership_var
         );
+    })
+    
+    observeEvent(input$go, {
+        updateTabItems(session = getDefaultReactiveDomain(), "tab", "plotting")
     })
     
     output$plot1 <- renderPlot({


### PR DESCRIPTION
Specifically, added an `updateTabItems()` call to automatically switch to main output tab when Run button is clicked. Added 'loading' spinners when simulation is run/re-run using [`shinycssloaders`](https://cran.r-project.org/web/packages/shinycssloaders/index.html), which suppresses plot output until ready, to clearly highlight simulations are running. Also proposed to move 'run' button to sidebar to avoid needing an entirely separate tab page with only an actionButton. Tested and working. These are all single changes from branch equal to master, so should be directly able to pull to master.