### PR TITLE
Proposed fix for #54. Branch oherwise level with master on 5 may 2021

### DIFF
--- a/R/gmse_apply.R
+++ b/R/gmse_apply.R
@@ -1307,9 +1307,9 @@ place_args <- function(all_names, placing_vals, arg_list){
         place_name <- placing_names[i];
         if(place_name %in% all_names){
             place_pos <- which(all_names == place_name);
-            arg_eval  <- eval(placing_vals[[i]], envir=sys.frame(sys.nframe()-3));
+            arg_eval  <- eval(placing_vals[[i]], envir = sys.frame(grep("gmse_apply", sys.calls())-1));
             if(is.null(arg_eval) == FALSE){
-                arg_list[[place_pos]] <- eval(placing_vals[[i]], envir=sys.frame(sys.nframe()-3));
+                arg_list[[place_pos]] <-eval(placing_vals[[i]], envir = sys.frame(grep("gmse_apply", sys.calls())-1));
             }
         }
     }

--- a/R/gmse_apply.R
+++ b/R/gmse_apply.R
@@ -1307,9 +1307,9 @@ place_args <- function(all_names, placing_vals, arg_list){
         place_name <- placing_names[i];
         if(place_name %in% all_names){
             place_pos <- which(all_names == place_name);
-            arg_eval  <- eval(placing_vals[[i]], envir=sys.frame(1));
+            arg_eval  <- eval(placing_vals[[i]], envir=sys.frame(sys.nframe()-3));
             if(is.null(arg_eval) == FALSE){
-                arg_list[[place_pos]] <- eval(placing_vals[[i]], envir=sys.frame(1));
+                arg_list[[place_pos]] <- eval(placing_vals[[i]], envir=sys.frame(sys.nframe()-3));
             }
         }
     }

--- a/R/gmse_apply.R
+++ b/R/gmse_apply.R
@@ -1307,9 +1307,9 @@ place_args <- function(all_names, placing_vals, arg_list){
         place_name <- placing_names[i];
         if(place_name %in% all_names){
             place_pos <- which(all_names == place_name);
-            arg_eval  <- eval(placing_vals[[i]]);
+            arg_eval  <- eval(placing_vals[[i]], envir=sys.frame(1));
             if(is.null(arg_eval) == FALSE){
-                arg_list[[place_pos]] <- eval(placing_vals[[i]]);
+                arg_list[[place_pos]] <- eval(placing_vals[[i]], envir=sys.frame(1));
             }
         }
     }

--- a/notebook/issue54_fix_example.R
+++ b/notebook/issue54_fix_example.R
@@ -135,3 +135,21 @@ GMSE_PARAS = list(land_dim_2 = 111)
 m = f10(gmse_paras = GMSE_PARAS)
 m$land_dim_2
 # OK
+
+rm(list=ls())
+
+alt_res <- function(X, K = 2000, rate = 1){
+    X_1 <- X + rate*X*(1 - X/K);
+    return(X_1);
+}
+
+w = function(ALT_RES, stakeholders) {
+    Y = 1111
+    gmse_apply(get_res = "Full", res_mod = ALT_RES, X = Y, stakeholders = stakeholders, my_way_or_the_highway = TRUE)
+}
+
+w(ALT_RES = alt_res, stakeholders = 5)
+
+
+stakeholders = 5
+gmse_apply(get_res = "Full", res_mod = alt_res, X = 1000, stakeholders = stakeholders, my_way_or_the_highway = TRUE)

--- a/notebook/issue54_fix_example.R
+++ b/notebook/issue54_fix_example.R
@@ -1,0 +1,113 @@
+### With proposed change in jeroen_issue54_fix branch, 5 may 2021
+
+rm(list=ls())
+
+global_ld1 = 111 # "global" parameter
+
+# This obviously works fine:
+m = gmse_apply(get_res = "Full", land_dim_1 = global_ld1)
+dim(m$LAND[,,1]) # Check of para used
+### OK.
+
+wrapper1 = function() {
+    print(global_ld1)
+    gmse_apply(get_res = "Full", land_dim_1 = global_ld1)
+}
+m2 = wrapper1()
+dim(m2$LAND[,,1])
+### OK.
+
+### Now we try to use a "local" para defined inside the wrapper:
+wrapper2 = function() {
+    local_ld1 = 222
+    print(local_ld1)
+    gmse_apply(get_res = "Full", land_dim_1 = local_ld1)
+}
+m3 = wrapper2()
+dim(m3$LAND[,,1])
+### OK.
+
+wrapper3 = function(ld1) {
+    print(ld1)
+    gmse_apply(get_res = "Full", land_dim_1 = ld1)
+}
+m4 = wrapper3(ld1 = 321)
+dim(m4$LAND[,,1])
+### OK.
+
+### Testing the above with some 'old_list' loops inside the wrapper:
+
+wrapper4 = function(ld1) {
+    M = list()
+    M[[1]] = gmse_apply(get_res = "Full", land_dim_1 = ld1)
+    for(i in 2:5) {
+        M[[i]] = gmse_apply(get_res = "Full", old_list = M[[i-1]])
+    }
+    return(M)
+}
+m5 = wrapper4(ld1 = 112)
+lapply(m5, function(x) dim(x$LAND[,,1])[1])
+### OK!
+
+### Testing some more with multiple varying parameters for the wrapper:
+
+wrapper5 = function(ld1, STAKEHOLDERS, LAND_OWNERSHIP) {
+    M = list()
+    M[[1]] = gmse_apply(get_res = "Full", land_dim_1 = ld1, stakeholders = STAKEHOLDERS, land_ownership = LAND_OWNERSHIP)
+    for(i in 2:5) {
+        M[[i]] = gmse_apply(get_res = "Full", old_list = M[[i-1]])
+    }
+    return(M)
+}
+m6 = wrapper5(ld1 = 113, STAKEHOLDERS = 3, LAND_OWNERSHIP = TRUE)
+lapply(m6, function(x) x$stakeholders) # OK
+lapply(m6, function(x) x$land_ownership) # OK
+lapply(m6, function(x) x$land_dim_1) # OK
+
+
+
+### Multiple wrappers:
+
+## Two:
+rm(list=ls())
+
+f1 = function(init_stakeholders) {
+    S = init_stakeholders
+    f2(STAKEHOLDERS = S)
+}
+
+f2 = function(STAKEHOLDERS) {
+    print(STAKEHOLDERS)
+    gmse_apply(get_res = "Full", stakeholders = STAKEHOLDERS)
+}
+
+m = f1(5)
+m$stakeholders
+# OK!
+
+## Three:
+f2 = function(STAKEHOLDERS) {
+    sholders = STAKEHOLDERS
+    f3(S = sholders)
+}
+
+f3 = function(S) {
+    gmse_apply(get_res = "Full", stakeholders = S)
+}
+
+m = f1(6)
+m$stakeholders
+# OK
+
+## With looping in inside wrapper:
+f3 = function(S) {
+    M = list()
+    M[[1]] = gmse_apply(get_res = "Full", stakeholders = S)
+    for(i in 2:5) {
+        M[[i]] = gmse_apply(get_res = "Full", old_list = M[[i-1]])
+    }
+    return(M)
+}
+M = f1(3)
+lapply(M, function(x) x$stakeholders)
+# OK

--- a/notebook/issue54_fix_example.R
+++ b/notebook/issue54_fix_example.R
@@ -111,3 +111,27 @@ f3 = function(S) {
 M = f1(3)
 lapply(M, function(x) x$stakeholders)
 # OK
+
+
+### Does it work when paras are in lists?
+rm(list=ls())
+
+f10 = function(x) {
+    GMSE_PARAS = list(land_dim_2 = 123)
+    gmse_apply(get_res = "Full", land_dim_2 = GMSE_PARAS$land_dim_2)
+}
+m = f10()
+m$land_dim_2
+# OK
+
+rm(list=ls())
+f10 = function(gmse_paras) {
+    f11(pars = gmse_paras)
+}
+f11 = function(pars) {
+    gmse_apply(get_res = "Full", land_dim_2 = pars$land_dim_2)
+}
+GMSE_PARAS = list(land_dim_2 = 111)
+m = f10(gmse_paras = GMSE_PARAS)
+m$land_dim_2
+# OK


### PR DESCRIPTION
This is a suggested fix for the issue raised in #54.

Basically a `gmse_apply` call seems to fail when it is wrapped inside a function (example [here](https://github.com/ConFooBio/gmse/issues/54#issuecomment-832560605)), I think because `eval(placing_vals[[i]])` attempts an evaluation of something that does not exist in the global environment (to which I think `eval()` defaults?).

I __think__ the proposed fix (`eval(placing_vals[[i]], envir=sys.frame(1))`) explicitly asks for the evaluation to happen in the _calling_ environment rather than local or global. As a result anything passed into a wrapper function should be picked up correctly; and when `gmse_apply` is called from the global environment, the end result should be the same.
Although this solution does appear to work (I will add some testing examples here), I am unsure whether this is an ideal solution- it essentially "breaks" local variable scope?